### PR TITLE
Correct "nativescript-meteor-client" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "babel-runtime": "^6.22.0",
     "meteor-rxjs": "^0.4.5",
     "nativescript-angular": "1.3.0",
-    "nativescript-meteor-client": "file:///home/ntrp/_PrivateWS/nativescript-meteor-client",
+    "nativescript-meteor-client": "0.0.5",
     "nativescript-ng2-fonticon": "1.3.4",
     "nativescript-telerik-ui": "1.5.1",
     "nativescript-theme-core": "0.2.1",


### PR DESCRIPTION
Replace local filesystem reference for "nativescript-meteor-client" in `package.json` devDependencies